### PR TITLE
Logo left padding link top padding

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -51,7 +51,7 @@ const NavHeader = styled.header`
   .hamb {
     cursor: pointer;
     float: right;
-    padding: 50px 20px;
+    padding: 65px 20px;
   }
 
   .hamb-line {

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -21,6 +21,7 @@ const NavHeader = styled.header`
     color: var(--white);
     font-size: 60px;
     padding-top: 0.2em;
+    padding-left: 0.2em;
   }
 
   /* Nav menu */
@@ -35,7 +36,7 @@ const NavHeader = styled.header`
     display: block;
     margin-left: 30px;
     padding-right: 0px;
-    padding-top: 25px;
+    padding-top: 37px;
     padding-bottom: 15px;
   }
 
@@ -132,6 +133,10 @@ const NavHeader = styled.header`
 
     .hamb {
       display: none;
+    }
+    
+    .logo {
+      padding-left: 0px;
     }
   }
 


### PR DESCRIPTION
On small screens with hamburger navigation there is no gap between the acm logo and side of screen:
![image](https://user-images.githubusercontent.com/16417432/214709425-fa28824f-07ed-4f57-9e4d-57c55a45f2e8.png)

The new logo is also a bit taller so the navigation bar links were no longer vertically centered on large  screens. 

I've updated the CSS to address both issues accordingly.