### PR TITLE
Fix Discord invites

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -57,7 +57,7 @@ export const Footer = () => (
           <Title>Connect with ACM @ UIUC</Title>
           <ExternalLinkDiv>
             <Href
-              href="https://discord.com/invite/strhfywPdw"
+              href="https://discord.gg/ec8VX6bBJx"
               target="_blank"
               rel="noreferrer"
             >

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -315,7 +315,7 @@ function Hero() {
               </Icon>
               <Icon>
                 <a
-                  href="https://discord.gg/strhfywPdw"
+                  href="https://discord.gg/ec8VX6bBJx"
                   target="_blank"
                   rel="noreferrer"
                 >


### PR DESCRIPTION
Previous Discord invites have been revoked/expired. The new Discord invite links were generated by Kylie and are set to never expire with max uses.